### PR TITLE
Add publishConfig to package.json to allow for public publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "This is the central repository for all icons used in our web products",
   "author": "Trimble",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "homepage": "https://github.com/trimble-oss/modus-icons",
   "repository": {


### PR DESCRIPTION
The `publishConfig` value manages the visibility of the package. If we define "public" access, then your package can be downloaded by everyone from the npm registry.
(scoped packages are private by default which we don't want)