### PR TITLE
Switch the order of the iconsets on homepage so Solid comes first

### DIFF
--- a/docs/layouts/_default/home.html
+++ b/docs/layouts/_default/home.html
@@ -25,32 +25,15 @@
         </div>
         <div class="col-12 col-sm-6 d-flex justify-content-end">
           <div class="ml-auto">
-                {{- highlight "npm i @trimble-oss/modus-icons" "sh" "" -}}
-              </div>
-              </div>
-              <div class="col-12">
-          <hr class="mt-0" />
+            {{- highlight "npm i @trimble-oss/modus-icons" "sh" "" -}}
           </div>
+        </div>
+        <div class="col-12">
+          <hr class="mt-0" />
+        </div>
       </div>
 
       <div class="row">
-        <div class="col-12 col-md-6">
-          <div class="card card-home border mb-3 mx-auto">
-            <div class="card-header bg-light border-0 text-center">
-              {{ partial "home/home-card-modus-icons" (dict "context" . "iconset" "modus-outlined") }}
-              </div>
-              <div class="card-body bg-light my-0 py-0">
-                <a href="/modus-outlined/" class="text-decoration-none stretched-link h2">
-                  Modus Outlined
-                </a>
-              </div>
-              <div class="card-footer bg-light mt-0 pt-0 small text-muted border-0">
-              {{ len (where .Site.RegularPages "Section" "=" "modus-outlined") }}
-              icons
-              </div>
-              </div>
-              </div>
-
         <div class="col-12 col-md-6">
           <div class="card card-home border mb-3">
             <div class="card-header bg-light border-0 text-center">
@@ -64,9 +47,25 @@
               <div class="card-footer bg-light mt-0 pt-0 small text-muted border-0">
               {{ len (where .Site.RegularPages "Section" "=" "modus-solid") }}
               icons
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-md-6">
+          <div class="card card-home border mb-3 mx-auto">
+            <div class="card-header bg-light border-0 text-center">
+              {{ partial "home/home-card-modus-icons" (dict "context" . "iconset" "modus-outlined") }}
               </div>
+              <div class="card-body bg-light my-0 py-0">
+                <a href="/modus-outlined/" class="text-decoration-none stretched-link h2">
+                  Modus Outlined
+                </a>
               </div>
-              </div>
+              <div class="card-footer bg-light mt-0 pt-0 small text-muted border-0">
+              {{ len (where .Site.RegularPages "Section" "=" "modus-outlined") }}
+              icons
+            </div>
+          </div>
+        </div>
       </div>
       <div class="row mt-3">
         <div class="col-12 my-4">

--- a/docs/layouts/_default/stats.html
+++ b/docs/layouts/_default/stats.html
@@ -2,7 +2,7 @@
 
 {{ .Content }}
 
-<h1 class="display-1 text-center mx-auto py-5 my-5">Stats</h1>
+<h1 class="display-1 text-center mx-auto py-4 my-4">Stats</h1>
 
 <div class="text-center">
   <p>

--- a/docs/layouts/modus-solid/single.html
+++ b/docs/layouts/modus-solid/single.html
@@ -51,8 +51,6 @@
 {{- $svgSpriteHtml := $svgSpriteSnippet | safeHTML -}}
 {{- $ligature := replace ( urlize .Title ) "-" "_" | lower -}}
 
-    <link rel="icon" href="data:image/svg+xml,{{ $svgHtml }}">
-
 <div class="row gx-lg-5">
   <div class="col-lg-7 mb-4">
     <div class="icon-demo mb-4 border rounded d-flex align-items-center justify-content-center p-3 py-6"

--- a/docs/layouts/partials/analytics.html
+++ b/docs/layouts/partials/analytics.html
@@ -1,6 +1,6 @@
 {{- if not .Site.IsServer -}}
 <script id="plausible" defer data-domain="modus-icons.trimble.com"
-  src="https://plausible.io/js/script.compat.outbound-links.js"></script>
+  src="https://plausible.io/js/script.compat.outbound-links.js" fetchpriority="low"></script>
 
 <script src="/js/trimble-insights.min.js"></script>
 <script>

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -48,5 +48,5 @@
 <button type="button" aria-label="scroll to top" class="btn-to-top border-0 position-fixed"></button>
 {{ $external := resources.Get "js/scroll-to-top.js" }}
 {{ $scrollToTopJs := slice $external | resources.Concat "js/scroll-to-top.js" | resources.Minify }}
-<script src="{{ $scrollToTopJs.RelPermalink }}" defer></script>
+<script src="{{ $scrollToTopJs.RelPermalink }}" defer fetchpriority="low"></script>
 {{ end }}

--- a/docs/layouts/partials/skippy.html
+++ b/docs/layouts/partials/skippy.html
@@ -1,3 +1,3 @@
-<a class="skippy visually-hidden-focusable sr-only" href="#content">
+<a class="skippy sr-only-focusable sr-only" href="#content">
   <span class="skippy-text">Skip to main content</span>
 </a>


### PR DESCRIPTION
Fixes: #139

PR Includes some minor HTML template fixes and performance micro-optimizations (adding `fetchpriority="low"` to analytics and scroll-to-top JS so that other deferred scripts are loaded ahead)