### PR TITLE
Package.json fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,6 @@
         "ttf2woff2": "^5.0.0",
         "underscore": "^1.7.0",
         "url-join": "^1.1.0"
-      },
-      "engines": {
-        "node": "16.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,8 @@
   "bugs": {
     "url": "https://github.com/trimble-oss/modus-icons/issues"
   },
-  "main": "./dist/modus.css",
-  "style": "./dist/modus.css",
   "keywords": [
-    "modus",
-    "icons"
+    "svg"
   ],
   "scripts": {
     "build": "node build/build.js && cd app-components && node build-components.js && cd ..",
@@ -82,9 +79,6 @@
     "ttf2woff2": "^5.0.0",
     "underscore": "^1.7.0",
     "url-join": "^1.1.0"
-  },
-  "engines": {
-    "node": "16.x"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- Removes `engines` field (not needed for end-users consuming this package)
- Remove modus and icons `keywords` (not needed as they are in the title of the package) and add svg keyword (so if someone searches for trimble svg icons this repo should show at npmjs.
- Remove `main` and `style` fields as these are not valid and gives incorrect CSS URLs at https://www.jsdelivr.com/package/npm/@trimble-oss/modus-icons