### PR TITLE
Exclude `/fonts/*.svg` and `/fonts/*.ttf` from npm package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,9 @@
     "dist",
     "LICENSE.md",
     "README.md",
-    "!.DS_Store"
+    "!.DS_Store",
+    "!**/fonts/*.svg",
+    "!**/fonts/*.ttf"
   ],
   "hugo-bin": {
     "buildTags": "extended"


### PR DESCRIPTION
Exclude `/fonts/*.svg` and `/fonts/*.ttf` from npm package. Not needed or used.

Results from `npm publish --dry-run`

![image](https://user-images.githubusercontent.com/1212885/220055490-ac75b8ad-6dd8-437f-80bd-52472ecda5d9.png)
