### PR TITLE
Remove unused Transportation icons

### DIFF
--- a/icons/transportation/envelope.svg
+++ b/icons/transportation/envelope.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-  <path d="M20 5H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2Zm-5.5 11h-8v-2h8v2Zm2-3.5h-10v-2h10v2Zm3.5-4h-2v-2h2v2Z"/>
-</svg>

--- a/icons/transportation/export.svg
+++ b/icons/transportation/export.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24">
-  <path d="M7.383 14.539V7.073h3.466v-2.8h5.775V14.54H18V3.16H9.466v.008L6 5.96v8.58h1.376Z"/>
-  <path d="M17.057 15.293h-3.791V10h-2.525v5.293H6.95l5.054 5.549Z"/>
-</svg>

--- a/icons/transportation/triangle-left.svg
+++ b/icons/transportation/triangle-left.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-  <path d="M14.29 5.71 8.7 11.3a.996.996 0 0 0 0 1.41l5.59 5.59c.63.63 1.71.18 1.71-.71V6.41c0-.89-1.08-1.34-1.71-.71Z"/>
-</svg>

--- a/icons/transportation/triangle-right.svg
+++ b/icons/transportation/triangle-right.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-  <path d="m9.71 18.29 5.59-5.59a.996.996 0 0 0 0-1.41L9.71 5.7C9.08 5.07 8 5.52 8 6.41v11.17c0 .89 1.08 1.34 1.71.71Z"/>
-</svg>


### PR DESCRIPTION
## Description

The Envelope, Export, Triangle-Left and Triangle-Right icons in the Transportation set are not used because they exist in Modus-Solid which is used when the icons get built.

Removing them saves a bit of time and keeps the build process a little bit quieter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Building locally generates the exact same output as these icons were not used at all anyway. No changes are expected as part of this PR.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
