### PR TITLE
Add `font-display: block` to CSS

### DIFF
--- a/fonts/css.hbs
+++ b/fonts/css.hbs
@@ -6,6 +6,7 @@
 
 @font-face {
   font-family: "{{fontName}}";
+  font-display: block;
   src: {{{src}}};
 }
 


### PR DESCRIPTION
## Description

This will improve display when using icon font by reducing content layout shifts. It won't display the text of the icon name before the icon font has loaded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v114.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
