### PR TITLE
Add Open Graph Images for Icon Pages

### DIFF
--- a/docs/layouts/partials/head.html
+++ b/docs/layouts/partials/head.html
@@ -1,6 +1,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{{- if .IsHome -}}{{- .Site.Title }} · {{ .Site.Params.description }}{{ else }}{{ .Title }} ({{ .Section | humanize | title -}}) · {{ .Site.Title -}}
+<title>{{- if .IsHome -}}{{- .Site.Title }} · {{ .Site.Params.description }}{{ else }}{{ .Title }}
+  ({{ .Section | humanize | title -}}) · {{ .Site.Title -}}
   {{- end -}}</title>
 
 <meta name="description"
@@ -8,13 +9,18 @@
 {{ if .IsHome }}
 <meta name="generator" content="Hugo {{ hugo.Version }}">
 {{ end }}
-<link rel="canonical" href="{{ .Permalink }}">
+<link rel="canonical" href="{{- .Permalink -}}">
 
 <meta name="color-scheme" content="light dark">
 {{ $themeToggle := resources.Get "js/theme-toggle.js" }}
 {{ $themeToggleJS := slice $themeToggle | resources.Concat "js/theme-toggle.js" | resources.Minify }}
-<script src="{{ $themeToggleJS.RelPermalink }}"></script>
+<script src="{{- $themeToggleJS.RelPermalink -}}"></script>
 
 {{ partial "stylesheet" . }}
 {{ partial "favicons" . }}
 {{ template "_internal/opengraph.html" . }}
+
+{{ if or .Params.tags .Params.categories -}}
+<meta property="og:image"
+  content="https://trimble-oss.github.io/modus-icons-opengraph/img/{{- .Section | urlize | lower -}}_{{- .Title | urlize | lower -}}.png">
+{{ end }}


### PR DESCRIPTION

## Description

Uses PNG images created with `capture-website-cli` and hosted at: https://github.com/trimble-oss/modus-icons-opengraph

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Locally I can see the image paths are correct.

You can test it by pasting an URL from the deploy preview (e.g. https://ambitious-sky-021d71010-285.centralus.2.azurestaticapps.net/modus-solid/trimble-logo/) in Slack, Google Chat or similar.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
