### PR TITLE
Add cookie-free Google Analytics

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -19,6 +19,7 @@
     "funcs",
     "gantt",
     "getenv",
+    "gtag",
     "horiz",
     "iframe",
     "incab",

--- a/.cspell.json
+++ b/.cspell.json
@@ -26,6 +26,8 @@
     "labelledby",
     "liga",
     "listjs",
+    "lntable",
+    "lntd",
     "markdownify",
     "mkdirp",
     "monetarization",
@@ -35,13 +37,13 @@
     "noscript",
     "npmjs",
     "onclick",
+    "opacity-50",
+    "opacity-75",
     "paren",
     "pe-none",
     "picocolors",
     "plainify",
     "pwsh",
-    "opacity-50",
-    "opacity-75",
     "qube",
     "rgba",
     "robotstxt",
@@ -72,7 +74,10 @@
     "Xhref",
     "xlink"
   ],
-  "flagWords": ["teh", "whitelist"],
+  "flagWords": [
+    "teh",
+    "whitelist"
+  ],
   "ignorePaths": [
     ".cspell.json",
     "**/node_modules/**",

--- a/.hintrc
+++ b/.hintrc
@@ -9,6 +9,7 @@
     "compat-api/html": "off",
     "meta-charset-utf-8": "off",
     "meta-viewport": "off",
-    "no-inline-styles": "off"
+    "no-inline-styles": "off",
+    "compat-api/css": "off"
   }
 }

--- a/docs/assets/scss/_footer.scss
+++ b/docs/assets/scss/_footer.scss
@@ -4,7 +4,6 @@
   contain-intrinsic-size: 333px;
   font-size: 14px;
   min-height: 333px;
-  color: #fff !important;
 }
 
 .footer p {

--- a/docs/layouts/modus-outlined/single.html
+++ b/docs/layouts/modus-outlined/single.html
@@ -134,10 +134,8 @@
       </div>
       <div>
         <nav class="navbar nav navbar-blue navbar-expand-sm modus-header px-2">
-          <a href="#navbar-example" class="navbar-brand me-auto ms-2">
-
+          <a href="#navbar-example" class="navbar-brand me-auto ms-2" aria-label="Home">
             {{- partial "logos/trimble.svg" (dict "class" "img-fluid d-none d-sm-block" "width" "107" "height" "25") -}}
-
             <img src="/{{ .Section | urlize }}/svg/trimble-logo.svg" class="d-block d-sm-none filter-invert" height="28"
               width="28" alt="home">
           </a>

--- a/docs/layouts/modus-solid/single.html
+++ b/docs/layouts/modus-solid/single.html
@@ -134,7 +134,7 @@
       </div>
       <div>
         <nav class="navbar nav navbar-blue navbar-expand-sm modus-header px-2">
-          <a href="#navbar-example" class="navbar-brand me-auto ms-2">
+          <a href="#navbar-example" class="navbar-brand me-auto ms-2" aria-label="Home">
             {{- partial "logos/trimble.svg" (dict "class" "img-fluid d-none d-sm-block" "width" "107" "height" "25") -}}
             <img src="/{{ .Section | urlize }}/svg/trimble-logo.svg" class="d-block d-sm-none filter-invert" height="28"
               width="28" alt="home">

--- a/docs/layouts/partials/analytics.html
+++ b/docs/layouts/partials/analytics.html
@@ -17,6 +17,19 @@
     };
 </script>
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-Y98EH56VN8" fetchpriority="low"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('consent', 'default', {
+    ad_storage: 'denied',
+    analytics_storage: 'denied',
+  }),
+  gtag('config', 'G-Y98EH56VN8');
+</script>
+
 <script src="/js/loglevel.min.js"></script>
 <script src="/js/loglevel-plugin-remote.min.js"></script>
 <script src="/js/tdcafLogger.min.js"></script>

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="footer p-3 p-md-5 mt-5 text-center text-sm-start">
+<footer class="footer p-3 p-md-5 mt-5 text-center text-sm-start text-white">
   <div class="container">
     <div class="row pt-2">
       <div class="col-12 mb-3 mt-1">

--- a/docs/layouts/transportation/single.html
+++ b/docs/layouts/transportation/single.html
@@ -126,7 +126,7 @@
       </div>
       <div>
         <nav class="navbar nav navbar-blue navbar-expand-sm modus-header px-2">
-          <a href="#navbar-example" class="navbar-brand me-auto ms-2">
+          <a href="#navbar-example" class="navbar-brand me-auto ms-2" aria-label="Home">
             {{- partial "logos/trimble.svg" (dict "class" "img-fluid d-none d-sm-block" "width" "107" "height" "25") -}}
             <img src="/{{- .Section | urlize -}}/svg/trimble-logo.svg" class="d-block d-sm-none filter-invert" height="28"
               width="28" alt="home">


### PR DESCRIPTION
## Description

Add GDPR-friendly Google Analytics which has NO user tracking at all (no cookies or localStorage used at all so no 'cookie banner' required).

Also minor a11y fix reported by AXE core.
