### PR TITLE
Release v1.16.1

### DIFF
--- a/fonts/css.hbs
+++ b/fonts/css.hbs
@@ -1,5 +1,5 @@
 /*!
- * Modus Icons v1.16.0 (https://modus-icons.trimble.com/)
+ * Modus Icons v1.16.1 (https://modus-icons.trimble.com/)
  * Copyright 2023-2025 Trimble Inc.
  * Licensed under MIT (https://github.com/trimble-oss/modus-icons/blob/main/LICENSE.md)
  */

--- a/hugo.yml
+++ b/hugo.yml
@@ -56,7 +56,7 @@ module:
 
 params:
   description:          "SVG icon library for Modus"
-  version:              "1.16.0"
+  version:              "1.16.1"
   main:                 "https://modus.trimble.com"
   github_org:           "https://github.com/trimble-oss"
   repo:                 "https://github.com/trimble-oss/modus-icons"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-icons",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-icons",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "MIT",
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-icons",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "This is the central repository for all icons used in our web products",
   "author": "Trimble",
   "publishConfig": {


### PR DESCRIPTION
This pull request updates the package version for the Modus Icons library from `1.16.0` to `1.16.1` in both the `package.json` and `hugo.yml` files. This is a routine version bump to reflect the latest release.

* Version updated to `1.16.1` in `package.json` to indicate the new release.
* Version updated to `1.16.1` in `hugo.yml` for consistency across documentation and tooling.