### PR TITLE
Improve GH Action Security

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy-preview.yml
+++ b/.github/workflows/azure-static-web-apps-deploy-preview.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
           submodules: true

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'trimble-oss/modus-icons'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -19,6 +19,6 @@ jobs:
     if: github.repository == 'trimble-oss/modus-icons'
 
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-reminder.yml
+++ b/.github/workflows/review-reminder.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use pinned commit SHAs for third-party actions, improving security and reliability by avoiding potential issues with version drift. The most important changes are grouped below.

**Security and Dependency Management:**

* All uses of `actions/checkout` across multiple workflow files (including `.github/workflows/azure-static-web-apps-deploy-preview.yml`, `.github/workflows/azure-static-web-apps-deploy.yml`, `.github/workflows/publish-to-npm.yml`, `.github/workflows/review-reminder.yml`, `.github/workflows/sonar-scan.yml`, `.github/workflows/spellcheck.yml`, `.github/workflows/super-linter.yml`, and `.github/workflows/test.yml`) have been updated to reference a specific commit SHA (`08c6903cd8c0fde910a37f88322edcfb5dd907a8`), corresponding to `v5.0.0`. This ensures that the exact version of the action is used in each workflow, rather than a potentially mutable tag. [[1]](diffhunk://#diff-acde36b19885fdcb30260c6e68befba481665c552c5a4100fe2fbb33cf97d139L19-R19) [[2]](diffhunk://#diff-f56718150ad81cc301d6693b0ff880df4943495658d85aa2a06200a5cd4b8443L15-R15) [[3]](diffhunk://#diff-d308a7dcddbca8dc6670f9395563eb37abf617ff85a54f5e6bd12967b55d7b65L19-R19) [[4]](diffhunk://#diff-b98a0ab726b2a384efefb17113ab4277fc8ca884b4ef38fb14059e4ea858bf43L15-R15) [[5]](diffhunk://#diff-81cec6cbfd8a75d84d3458b1861f5804dfa41ae74b674f633952fe7762cd84d5L29-R29) [[6]](diffhunk://#diff-203285d1aa85b30b7cd672df926f6239c419f1308a5b1cbe3c5df4a0497f1dafL25-R25) [[7]](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L23-R23) [[8]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L23-R23)

* The `release-drafter/release-drafter` action in `.github/workflows/release-notes.yml` is now pinned to a specific commit SHA (`b1476f6e6eb133afa41ed8589daba6dc69b4d3f5`), corresponding to `v6.1.0`, instead of a floating tag.