### PR TITLE
GitHub Action Fixes

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy-preview.yml
+++ b/.github/workflows/azure-static-web-apps-deploy-preview.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
           cache: "npm"

--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
           cache: "npm"

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "${{ env.NODE }}"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: streetsidesoftware/cspell-action@v7
+      - uses: streetsidesoftware/cspell-action@157048954070986ce4315d0813573a2d8faee361 # v7.1.1
         with:
           check_dot_files: false
           incremental_files_only: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "${{ env.NODE }}"
           cache: npm
@@ -46,7 +46,7 @@ jobs:
         run: npm test
 
       - name: Run linkinator
-        uses: JustinBeckwith/linkinator-action@v1
+        uses: JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d # v1.11.0
         with:
           paths: _site
           markdown: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "6.0.0",
         "@prettier/plugin-xml": "3.4.1",
-        "@trimble-oss/modus-bootstrap": "2.1.0",
+        "@trimble-oss/modus-bootstrap": "2.0.13",
         "autoprefixer": "10.4.21",
         "bootstrap": "5.3.8",
         "clipboard": "2.0.11",
@@ -898,13 +898,13 @@
       }
     },
     "node_modules/@trimble-oss/modus-bootstrap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-bootstrap/-/modus-bootstrap-2.1.0.tgz",
-      "integrity": "sha512-fpRJ8TTetIvcA938Qzb09sXQDAHnz63WIWFcHrpLkzqhETLsgplLD/XfHp2UdvWLb2N2erYgAMzagYFwAp8+SQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-bootstrap/-/modus-bootstrap-2.0.13.tgz",
+      "integrity": "sha512-SQ/x7gH5Ao9ezIdPwDK1P6b54UPrXrG7rd5R/tu8e8pg7GwP7KePFKJbis4NXk24n8OJs3Ls4V7PRu9GQsJncg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bootstrap": "^5.3.8"
+        "bootstrap": "^5.3.7"
       }
     },
     "node_modules/@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "6.0.0",
     "@prettier/plugin-xml": "3.4.1",
-    "@trimble-oss/modus-bootstrap": "2.1.0",
+    "@trimble-oss/modus-bootstrap": "2.0.13",
     "autoprefixer": "10.4.21",
     "bootstrap": "5.3.8",
     "clipboard": "2.0.11",


### PR DESCRIPTION
This pull request updates several GitHub Actions in workflow files to use specific commit SHAs instead of version tags, improving supply chain security by pinning dependencies. Additionally, it downgrades the `@trimble-oss/modus-bootstrap` development dependency to an earlier version.

**Workflow dependency pinning:**

* Updated `actions/setup-node` to use a specific commit SHA (`49933ea5288caeca8642d1e84afbd3f7d6820020`, v4.4.0) instead of the `v5` tag in `.github/workflows/azure-static-web-apps-deploy-preview.yml`, `.github/workflows/azure-static-web-apps-deploy.yml`, `.github/workflows/publish-to-npm.yml`, and `.github/workflows/test.yml` [[1]](diffhunk://#diff-acde36b19885fdcb30260c6e68befba481665c552c5a4100fe2fbb33cf97d139L24-R24) [[2]](diffhunk://#diff-f56718150ad81cc301d6693b0ff880df4943495658d85aa2a06200a5cd4b8443L20-R20) [[3]](diffhunk://#diff-d308a7dcddbca8dc6670f9395563eb37abf617ff85a54f5e6bd12967b55d7b65L23-R23) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L28-R28).
* Updated `streetsidesoftware/cspell-action` to a specific commit SHA (`157048954070986ce4315d0813573a2d8faee361`, v7.1.1) in `.github/workflows/spellcheck.yml`.
* Updated `JustinBeckwith/linkinator-action` to a specific commit SHA (`3d5ba091319fa7b0ac14703761eebb7d100e6f6d`, v1.11.0) in `.github/workflows/test.yml`.

**Dependency version change:**

* Downgraded `@trimble-oss/modus-bootstrap` from version `2.1.0` to `2.0.13` in `package.json`.