### PR TITLE
Update iconType detection in SVGO config

### DIFF
--- a/build/logic/svgo.config.js
+++ b/build/logic/svgo.config.js
@@ -51,7 +51,7 @@ module.exports = {
         }
 
         const basename = path.basename(info.path, '.svg');
-        const iconType = info.path.includes('outline') ? 'outline' : 'solid';
+        const iconType = info.path.includes('connect') ? 'connect' : (info.path.includes('outline') ? 'outline' : 'solid');
         return {
           element: {
             enter(node, parentNode) {


### PR DESCRIPTION
Adjusts the logic to set iconType to 'connect' if the SVG path includes 'connect', otherwise falls back to 'outline' or 'solid'. This allows for more granular handling of SVG icon types during optimization.
