### PR TITLE
Update Dependabot config and Mend scan workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       - dependencies
     versioning-strategy: increase
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/mendscan.yml
+++ b/.github/workflows/mendscan.yml
@@ -2,8 +2,6 @@
 name: 'Mend CLI Scan'
 
 on:
-  pull_request:
-    types: ['opened', 'synchronize', 'reopened']
   schedule:
     - cron: '0 0 1 * *'
   workflow_dispatch: {}

--- a/app-components/package-lock.json
+++ b/app-components/package-lock.json
@@ -48,7 +48,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "sass": "1.79.1",
-        "ts-node": "^9.0.0",
+        "ts-node": "^9.1.1",
         "typescript": "~5.2.2"
       },
       "engines": {

--- a/docs/layouts/partials/usage.html
+++ b/docs/layouts/partials/usage.html
@@ -20,12 +20,12 @@
       CSS—from our CDN and get started in seconds. <a href="#icon-font">See icon font docs</a> for examples.</p>
     <div class="highlight">
       <pre tabindex="0"
-        class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"stylesheet"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.17.0/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="p">&gt;</span></span></span></code></pre>
+        class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"stylesheet"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.18.1/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="p">&gt;</span></span></span></code></pre>
     </div>
 
     <div class="highlight">
       <pre tabindex="0"
-        class="chroma"><code class="language-css" data-lang="css"><span class="line"><span class="cl"><span class="p">@</span><span class="k">import</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.17.0/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="o">)</span><span class="p">;</span></span></span></code></pre>
+        class="chroma"><code class="language-css" data-lang="css"><span class="line"><span class="cl"><span class="p">@</span><span class="k">import</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.18.1/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="o">)</span><span class="p">;</span></span></span></code></pre>
     </div>
   </div>
   <div class="col-md-4">


### PR DESCRIPTION
Dependabot is now configured to ignore major version updates for all dependencies. The Mend CLI scan workflow no longer runs on pull requests, only on schedule or manual dispatch. Also updated ts-node and modus-icons versions in package-lock and documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Dependabot to ignore npm major updates in `app-components`, limits Mend scan to scheduled/manual runs, and updates `ts-node` and CDN docs to latest versions.
> 
> - **CI/Automation**:
>   - **Dependabot**: Add global ignore for npm major updates in `app-components/` via `ignore: { dependency-name: "*", update-types: ["version-update:semver-major"] }`.
>   - **Mend Scan Workflow**: Remove `pull_request` trigger; now runs only on schedule or manual dispatch.
> - **Dependencies**:
>   - Bump `ts-node` in `app-components/package-lock.json` from `^9.0.0` to `^9.1.1`.
> - **Docs**:
>   - Update CDN references in `docs/layouts/partials/usage.html` from `@trimble-oss/modus-icons@1.17.0` to `@1.18.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66189b5d3cb2e408bf96d40be7be60d838dd9764. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->