### PR TITLE
Remove document-register-element polyfill

### DIFF
--- a/app-components/package-lock.json
+++ b/app-components/package-lock.json
@@ -19,7 +19,6 @@
         "@angular/platform-browser-dynamic": "^17.3.0",
         "@angular/router": "^17.3.0",
         "@webcomponents/webcomponentsjs": "^2.8.0",
-        "document-register-element": "^1.7.2",
         "ngx-bootstrap": "^12.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -7039,13 +7038,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/document-register-element": {
-      "version": "1.14.10",
-      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.14.10.tgz",
-      "integrity": "sha512-w5UA37hEIrs+9pruo2yR5UD13c4UHDlkqqjt4qurnp7QsBI9b1IOi8WXUim+aCqKBsENX3Z/cso7XMOuwJH1Yw==",
-      "deprecated": "V0 is gone and the best V1 polyfill is now @ungap/custom-elements",
-      "license": "ISC"
     },
     "node_modules/dom-serialize": {
       "version": "2.2.1",

--- a/app-components/package.json
+++ b/app-components/package.json
@@ -21,7 +21,6 @@
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
     "@webcomponents/webcomponentsjs": "^2.8.0",
-    "document-register-element": "^1.7.2",
     "ngx-bootstrap": "^12.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/app-components/src/polyfills.ts
+++ b/app-components/src/polyfills.ts
@@ -62,5 +62,4 @@ import 'zone.js'; // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
-import 'document-register-element';
 import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js';


### PR DESCRIPTION
Eliminated the deprecated 'document-register-element' dependency from package.json, package-lock.json, and polyfills.ts. The project now relies on '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js' for custom elements support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove deprecated `document-register-element` dependency and its polyfill import, relying on the Web Components ES5 adapter instead.
> 
> - **Dependencies**:
>   - Remove deprecated `document-register-element` from `app-components/package.json` and `package-lock.json`.
> - **Polyfills**:
>   - Delete `document-register-element` import from `app-components/src/polyfills.ts`.
>   - Continue using `@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cbbeb6c74e5f7934c78f0d28d457b1a287ce59d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->