### PR TITLE
Update a11y-scan.yml with specific URLs and repo

### DIFF
--- a/.github/workflows/a11y-scan.yml
+++ b/.github/workflows/a11y-scan.yml
@@ -13,5 +13,5 @@ jobs:
             https://modus-icons.trimble.com/modus-solid/alert/
           repository: trimble-oss/modus-icons # Provide a repository name-with-owner (in the format "primer/primer-docs"). This is where issues will be filed and where Copilot will open PRs; more information below.
           token: ${{ secrets.GH_TOKEN }} # This token must have write access to the repo above (contents, issues, and PRs); more information below. Note: GitHub Actions' GITHUB_TOKEN cannot be used here.
-          cache_key: REPLACE_THIS # Provide a filename that will be used when caching results. We recommend including the name or domain of the site being scanned.
+          cache_key: modus-icons-trimble-com # Provide a filename that will be used when caching results. We recommend including the name or domain of the site being scanned.
           # skip_copilot_assignment: false # Optional: Set to true to skip assigning issues to GitHub Copilot (or if you don't have GitHub Copilot)


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for running accessibility scans on the project’s public URLs. The workflow is set up to be triggered manually and uses the `github/accessibility-scanner` action to check multiple URLs for accessibility issues.

**CI/CD and Accessibility Improvements:**

* Added a new workflow file `.github/workflows/a11y-scan.yml` to enable manual execution of accessibility scans on key project URLs using the `github/accessibility-scanner` action. The workflow is configured to create issues and PRs in the `trimble-oss/modus-icons` repository and requires a custom token for authentication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a manually triggered GitHub Actions workflow to run github/accessibility-scanner on selected Modus Icons URLs and file results to trimble-oss/modus-icons.
> 
> - **CI/CD**:
>   - **New workflow**: `/.github/workflows/a11y-scan.yml`
>     - Runs `github/accessibility-scanner@v2` against specified URLs (`modus-icons.trimble.com` paths).
>     - Files issues/PRs to `trimble-oss/modus-icons` using `secrets.GH_TOKEN`.
>     - Uses `workflow_dispatch` trigger and `cache_key` `modus-icons-trimble-com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4780b082d83da9cbdfc09a6f7a7da49f77644ad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->