### PR TITLE
Bump version to 1.20.0

### DIFF
--- a/docs/layouts/partials/usage.html
+++ b/docs/layouts/partials/usage.html
@@ -20,12 +20,12 @@
       CSS—from our CDN and get started in seconds. <a href="#icon-font">See icon font docs</a> for examples.</p>
     <div class="highlight">
       <pre tabindex="0"
-        class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"stylesheet"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.19.0/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="p">&gt;</span></span></span></code></pre>
+        class="chroma"><code class="language-html" data-lang="html"><span class="line"><span class="cl"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"stylesheet"</span> <span class="na">href</span><span class="o">=</span><span class="s">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.20.0/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="p">&gt;</span></span></span></code></pre>
     </div>
 
     <div class="highlight">
       <pre tabindex="0"
-        class="chroma"><code class="language-css" data-lang="css"><span class="line"><span class="cl"><span class="p">@</span><span class="k">import</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.19.0/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="o">)</span><span class="p">;</span></span></span></code></pre>
+        class="chroma"><code class="language-css" data-lang="css"><span class="line"><span class="cl"><span class="p">@</span><span class="k">import</span> <span class="nt">url</span><span class="o">(</span><span class="s2">"https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.20.0/dist/{{ with .iconset }}{{- . -}}{{ end }}/fonts/modus-icons.css"</span><span class="o">)</span><span class="p">;</span></span></span></code></pre>
     </div>
   </div>
   <div class="col-md-4">

--- a/fonts/css.hbs
+++ b/fonts/css.hbs
@@ -1,5 +1,5 @@
 /*!
- * Modus Icons v1.19.0 (https://modus-icons.trimble.com/)
+ * Modus Icons v1.20.0 (https://modus-icons.trimble.com/)
  * Copyright 2023-2025 Trimble Inc.
  * Licensed under MIT (https://github.com/trimble-oss/modus-icons/blob/main/LICENSE.md)
  */

--- a/hugo.yml
+++ b/hugo.yml
@@ -58,7 +58,7 @@ module:
 
 params:
   description:          "SVG icon library for Modus"
-  version:              "1.19.0"
+  version:              "1.20.0"
   main:                 "https://modus.trimble.com"
   github_org:           "https://github.com/trimble-oss"
   repo:                 "https://github.com/trimble-oss/modus-icons"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-icons",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-icons",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "MIT",
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-icons",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "This is the central repository for all icons used in our web products",
   "author": "Trimble",
   "publishConfig": {


### PR DESCRIPTION
Update project version to 1.20.0. Modified package.json and package-lock.json, updated hugo.yml params, refreshed fonts/css.hbs header, and adjusted CDN links in docs/layouts/partials/usage.html to reference the new 1.20.0 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure version/documentation string updates (npm metadata, Hugo site params, and CDN URLs) with no functional code changes; risk is limited to potential mismatched version references if anything was missed.
> 
> **Overview**
> Bumps Modus Icons version references from `1.19.0` to `1.20.0` across the project.
> 
> Updates npm package metadata (`package.json`, `package-lock.json`), the docs site’s displayed version (`hugo.yml`), the generated font CSS header (`fonts/css.hbs`), and the CDN usage examples in `docs/layouts/partials/usage.html` to point at the `1.20.0` release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59a16864bf960b2eb32300227942860f2dd8eeb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->