### PR TITLE
Remove ngx-bootstrap and add native dropdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,11 +51,11 @@ New glyphs are designed on a 24x24px grid, then exported as flattened SVGs. Once
 
 ### SVGs
 
-- Must be 24x24px. (the first line of the SVG should be `<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">`)
+- Must be 24x24px. (the first line of the SVG should be `<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">`).
 - Must be flattened.
 - Should not use any color other than `currentColor`.
 - Should not use transforms as these often cause inconsistencies when building.
-- Must not include any stroke attributes. (these will be removed by the build script)
-- Should not use any ids, styles, filters or xlink attributes. (these will be removed by the build script)
-- Should not include any bitmap images
+- Must not include any stroke attributes. (these will be removed by the build script).
+- Should not use any ids, styles, filters or xlink attributes. (these will be removed by the build script).
+- Should not include any bitmap images.
 - Before submitting, preview at small sizes (16px, 24px, 32px) to confirm clarity.

--- a/app-components/.npmrc
+++ b/app-components/.npmrc
@@ -1,2 +1,3 @@
 lockfile-version = 3
 registry = 'https://registry.npmjs.org/'
+omit = peer

--- a/app-components/package-lock.json
+++ b/app-components/package-lock.json
@@ -8,7 +8,6 @@
       "name": "app-components",
       "version": "0.0.0",
       "dependencies": {
-        "@angular/animations": "^21.2.17",
         "@angular/cdk": "^21.2.14",
         "@angular/common": "^21.2.17",
         "@angular/compiler": "^21.2.17",
@@ -16,10 +15,8 @@
         "@angular/elements": "^21.2.17",
         "@angular/forms": "^21.2.17",
         "@angular/platform-browser": "^21.2.17",
-        "@angular/platform-browser-dynamic": "^21.2.15",
         "@angular/router": "^21.2.17",
         "@webcomponents/webcomponentsjs": "^2.8.0",
-        "ngx-bootstrap": "21.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.16.0"
@@ -1386,6 +1383,8 @@
       "integrity": "sha512-zOW8FFa9qfbVkZ5TulxDkl1C3+gEjWfAAD5Z2MycA6pjVJQlLYPiTAGq+flOQ3yZfTT0z6kd5rejQMXWI81Dvg==",
       "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1636,25 +1635,6 @@
         "@angular/animations": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.17.tgz",
-      "integrity": "sha512-r/BU/T8bOTghP3fIXhzYf5wcMcAmhWnAFv3p4asCCPXomaktoas70wYcMaDH+pK1LAFBxLwzBWHm36MpFlTMFg==",
-      "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "21.2.17",
-        "@angular/compiler": "21.2.17",
-        "@angular/core": "21.2.17",
-        "@angular/platform-browser": "21.2.17"
       }
     },
     "node_modules/@angular/router": {
@@ -13282,22 +13262,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ngx-bootstrap": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-21.2.0.tgz",
-      "integrity": "sha512-JQucz35YZaLlza1osz1cZWWXCGxqWmJTdEfju7F/tNkv6esfAzcwvUe3AMwz6oasZ/NfBMNlxNj7woIlYObR+A==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "^21.2.0",
-        "@angular/common": "^21.2.0",
-        "@angular/core": "^21.2.0",
-        "@angular/forms": "^21.2.0",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",

--- a/app-components/package.json
+++ b/app-components/package.json
@@ -10,7 +10,6 @@
     "lint": "ng lint"
   },
   "dependencies": {
-    "@angular/animations": "^21.2.17",
     "@angular/cdk": "^21.2.14",
     "@angular/common": "^21.2.17",
     "@angular/compiler": "^21.2.17",
@@ -18,10 +17,8 @@
     "@angular/elements": "^21.2.17",
     "@angular/forms": "^21.2.17",
     "@angular/platform-browser": "^21.2.17",
-    "@angular/platform-browser-dynamic": "^21.2.17",
     "@angular/router": "^21.2.17",
     "@webcomponents/webcomponentsjs": "^2.8.0",
-    "ngx-bootstrap": "21.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.16.0"

--- a/app-components/src/app/app.module.ts
+++ b/app-components/src/app/app.module.ts
@@ -13,16 +13,11 @@ import { SetComponent } from './set/set.component';
 import { SvgcssComponent } from './svgcss/svgcss.component';
 import { FilterPipe } from './_pipes/filter.pipe';
 
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
 @NgModule({
     declarations: [SearchComponent, SetComponent, FilterPipe, SvgcssComponent],
     imports: [
         BrowserModule,
         FormsModule,
-        BsDropdownModule,
-        BrowserAnimationsModule,
     ],
     providers: [
     // { provide: OverlayContainer, useClass: CdkOverlayContainer }

--- a/app-components/src/app/set/set.component.html
+++ b/app-components/src/app/set/set.component.html
@@ -23,8 +23,7 @@
         <ul id="dropdown-basic" class="dropdown-menu" [class.show]="dropdownOpen" role="menu"
           aria-labelledby="button-basic">
           <li role="menuitem" *ngFor="let cat of categoryList">
-            <a class="dropdown-item" (click)="selectCategory(cat)" [ngClass]="{ active: selectedCategory === cat }"
-              href="javascript: void(0);">{{ cat }}</a>
+            <button type="button" class="dropdown-item" (click)="selectCategory(cat)" [ngClass]="{ active: selectedCategory === cat }">{{ cat }}</button>
           </li>
         </ul>
       </div>

--- a/app-components/src/app/set/set.component.html
+++ b/app-components/src/app/set/set.component.html
@@ -14,12 +14,14 @@
       <label class="form-check-label me-2" for="Switch1">Show categories</label>
     </div>
     <div class="d-flex flex-column">
-      <div class="btn-group" dropdown>
-        <button id="button-basic" dropdownToggle type="button" [disabled]="filterTerm !== ''"
-          class="btn btn-outline-secondary dropdown-toggle" aria-controls="dropdown-basic">
+      <div class="btn-group" (click)="$event.stopPropagation()">
+        <button id="button-basic" type="button" [disabled]="filterTerm !== ''"
+          class="btn btn-outline-secondary dropdown-toggle" aria-controls="dropdown-basic"
+          [attr.aria-expanded]="dropdownOpen" (click)="toggleDropdown($event)">
           Categories
         </button>
-        <ul id="dropdown-basic" *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="button-basic">
+        <ul id="dropdown-basic" class="dropdown-menu" [class.show]="dropdownOpen" role="menu"
+          aria-labelledby="button-basic">
           <li role="menuitem" *ngFor="let cat of categoryList">
             <a class="dropdown-item" (click)="selectCategory(cat)" [ngClass]="{ active: selectedCategory === cat }"
               href="javascript: void(0);">{{ cat }}</a>

--- a/app-components/src/app/set/set.component.spec.ts
+++ b/app-components/src/app/set/set.component.spec.ts
@@ -54,4 +54,11 @@ describe('SetComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should close the categories dropdown when filtering', () => {
+    component.dropdownOpen = true;
+    component.filterIcons('search');
+    expect(component.dropdownOpen).toBeFalse();
+    expect(component.filterTerm).toBe('search');
+  });
 });

--- a/app-components/src/app/set/set.component.spec.ts
+++ b/app-components/src/app/set/set.component.spec.ts
@@ -1,8 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormsModule } from '@angular/forms';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { of } from 'rxjs';
 
 import { SetComponent } from './set.component';
@@ -22,8 +20,6 @@ describe('SetComponent', () => {
       imports: [
         HttpClientTestingModule,
         FormsModule,
-        BrowserAnimationsModule,
-        BsDropdownModule
       ],
       providers: [
         { provide: IconService, useValue: spy }

--- a/app-components/src/app/set/set.component.ts
+++ b/app-components/src/app/set/set.component.ts
@@ -68,6 +68,9 @@ export class SetComponent implements OnInit {
 
   filterIcons(term: string): void {
     this.filterTerm = term;
+    if (term !== '') {
+      this.dropdownOpen = false;
+    }
     if (term === '') {
       window.history.replaceState(null, null, window.location.pathname);
     } else {

--- a/app-components/src/app/set/set.component.ts
+++ b/app-components/src/app/set/set.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, HostListener, Input, OnInit } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { IconService } from '../icon.service';
 
@@ -19,6 +19,7 @@ export class SetComponent implements OnInit {
   hasCategories: boolean;
   showCategories = true;
   filterTerm = '';
+  dropdownOpen = false;
   fontCssUrl: SafeResourceUrl;
 
   constructor(
@@ -78,9 +79,20 @@ export class SetComponent implements OnInit {
     }
   }
 
+  toggleDropdown(event: Event): void {
+    event.stopPropagation();
+    this.dropdownOpen = !this.dropdownOpen;
+  }
+
+  @HostListener('document:click')
+  closeDropdown(): void {
+    this.dropdownOpen = false;
+  }
+
   selectCategory(cat: string): void {
     this.selectedCategory = cat;
     this.showCategories = true;
+    this.dropdownOpen = false;
     if (cat === 'All') {
       window.history.replaceState(null, null, window.location.pathname);
     } else {

--- a/app-components/src/main.ts
+++ b/app-components/src/main.ts
@@ -1,6 +1,6 @@
 import './polyfills';
 import { enableProdMode } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { platformBrowser } from '@angular/platform-browser';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
@@ -9,6 +9,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic()
+platformBrowser()
   .bootstrapModule(AppModule)
   .catch((err) => console.error(err));

--- a/app-components/src/test.ts
+++ b/app-components/src/test.ts
@@ -1,14 +1,15 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
+import 'zone.js';
 import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
-} from '@angular/platform-browser-dynamic/testing';
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  BrowserTestingModule,
+  platformBrowserTesting()
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5151,10 +5151,20 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10365,10 +10375,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },


### PR DESCRIPTION
## Description

- Remove ngx-bootstrap and related BrowserAnimationsModule usage and implement a native dropdown in SetComponent. 
- Replace BsDropdownModule-driven template with a manual dropdown controlled by dropdownOpen, toggleDropdown and a document click HostListener; close dropdown on selection. 
- Update bootstrapping to use platformBrowser and switch tests to BrowserTestingModule/platformBrowserTesting. 
- Add `omit = peer` to app-components/.npmrc and apply minor punctuation fixes in CONTRIBUTING.md.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the docs Angular demo UI and dependency cleanup; category dropdown behavior is localized with a small new test.
> 
> **Overview**
> Removes **ngx-bootstrap** and **@angular/animations** / **BrowserAnimationsModule** from the docs `app-components` Angular app, shrinking dependencies and avoiding peer installs via **`omit = peer`** in `app-components/.npmrc`.
> 
> The icon set **Categories** control in `SetComponent` is reimplemented with Bootstrap markup: **`dropdownOpen`**, **`toggleDropdown`**, a document **`click`** listener to dismiss, and closing when filtering or picking a category. Menu entries use **`<button>`** instead of `javascript:` links. Bootstrapping switches from **`platformBrowserDynamic`** to **`platformBrowser`**; Karma setup uses **`BrowserTestingModule`** / **`platformBrowserTesting`**, with a unit test that the dropdown closes when filtering.
> 
> **CONTRIBUTING.md** gets minor punctuation on SVG rules; root **package-lock** bumps **js-yaml** and **ws** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2d36e8189233261af65312143924e93928a646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->