### PR TITLE
SonarQube Linting Fixes

### DIFF
--- a/app-components/src/styles.scss
+++ b/app-components/src/styles.scss
@@ -1,12 +1,5 @@
-// @import "../node_modules/@angular/cdk/_overlay";
-
 .cdk-overlay-container {
   pointer-events: none;
   position: absolute;
-
-  // top: 0;
-  // left: 0;
-  // height: 100%;
-  // width: 100%;
   z-index: 1000;
 }

--- a/docs/assets/scss/_syntax.scss
+++ b/docs/assets/scss/_syntax.scss
@@ -1,15 +1,6 @@
 // stylelint-disable comment-empty-line-before
 // stylelint-disable declaration-block-single-line-max-declarations
 
-/* Background .chroma { background-color: #f0f0f0; } */
-/* Other .chroma .x { } */
-/* Error .chroma .err { } */
-/* LineTableTD .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; } */
-/* LineTable .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; } */
-/* LineHighlight .chroma .hl { display: block; width: 100%; background-color: #ffffcc; } */
-/* LineNumbersTable .chroma .lnt { margin-right: .4em; padding: 0 .4em; } */
-/* LineNumbers .chroma .ln { margin-right: .4em; padding: 0 .4em; } */
-
 /* Comment */ .chroma .c { color: #777; }
 /* CommentHashbang */ .chroma .ch { font-style: italic; color: #60a0b0; }
 /* CommentMultiline */ .chroma .cm { color: #777; }

--- a/docs/layouts/_default/stats.html
+++ b/docs/layouts/_default/stats.html
@@ -37,7 +37,7 @@
 </div>
 
 <div class="col-12 col-sm-11 col-md-10 col-lg-9 col-xl-8 mx-auto mt-3">
-  <table class="table table-bordered border mx-auto w-75 mt-3" role="none">
+  <table class="table table-bordered border mx-auto w-75 mt-3">
     <thead class="bg-light">
       <tr>
         <th scope="col" class="w-50">Icon Sets</th>
@@ -64,7 +64,7 @@
         <td><a href="/field-systems/">Field Systems</a></td>
         <td>{{ len (where .Site.RegularPages "Section" "=" "field-systems") }}</td>
       </tr>
-        <tr>
+      <tr>
         <td class="fw-bold">Total:</td>
         <td class="fw-bold">{{ len (where .Site.RegularPages "Section" "!=" "") }}</td>
       </tr>

--- a/docs/layouts/partials/analytics.html
+++ b/docs/layouts/partials/analytics.html
@@ -1,6 +1,6 @@
 {{- if not hugo.IsServer -}}
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-Y98EH56VN8" fetchpriority="low"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-Y98EH56VN8"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}

--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -48,5 +48,5 @@
 <button type="button" aria-label="scroll to top" class="btn-to-top border-0 position-fixed"></button>
 {{ $external := resources.Get "js/scroll-to-top.js" }}
 {{ $scrollToTopJs := slice $external | resources.Concat "js/scroll-to-top.js" | resources.Minify }}
-<script src="{{ $scrollToTopJs.RelPermalink }}" defer fetchpriority="low"></script>
+<script src="{{ $scrollToTopJs.RelPermalink }}" defer></script>
 {{ end }}


### PR DESCRIPTION
This pull request contains minor updates to stylesheets and HTML templates, primarily focused on code cleanup and minor optimizations. The changes remove unnecessary or commented-out code and adjust script-loading attributes for performance.

**Code cleanup and style adjustments:**

* Removed commented-out import and unused CSS properties from `app-components/src/styles.scss` for cleaner styles.
* Deleted several commented-out style rules related to syntax highlighting in `docs/assets/scss/_syntax.scss` to reduce clutter.

**HTML and script optimizations:**

* Removed the `role="none"` attribute from the stats table in `docs/layouts/_default/stats.html` for cleaner markup.
* Removed the `fetchpriority="low"` attribute from the Google Analytics script in `docs/layouts/partials/analytics.html` to use default loading behavior.
* Removed the `fetchpriority="low"` attribute from the scroll-to-top script in `docs/layouts/partials/footer.html` for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic lint and markup-only edits with no auth, data, or business-logic changes; script loading behavior may differ slightly after removing `fetchpriority="low"`.
> 
> **Overview**
> Cleans up SCSS and Hugo templates to satisfy SonarQube lint rules, with no functional feature work.
> 
> **Styles:** Removes commented-out CDK overlay import and unused positioning rules from `app-components/src/styles.scss`, and deletes empty/comment-only Chroma syntax-highlight blocks at the top of `docs/assets/scss/_syntax.scss`.
> 
> **Docs markup:** Drops `role="none"` from the stats page icon-count table and fixes indentation on the total row in `stats.html`. Removes `fetchpriority="low"` from the gtag loader in `analytics.html` and from the deferred scroll-to-top script in `footer.html`, so those scripts use default fetch priority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47691295cf47d1e51519d93317e8954db1115849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->