### PR TITLE
Bump modus-icons-css CDN to 0.10.0

### DIFF
--- a/docs/assets/js/css-icons-gallery.js
+++ b/docs/assets/js/css-icons-gallery.js
@@ -8,7 +8,7 @@
   /** Delay filter re-renders while typing to avoid rebuilding thousands of nodes per keystroke. */
   var FILTER_DEBOUNCE_MS = 120;
 
-  var ICONS_CSS_VERSION = "0.9.0";
+  var ICONS_CSS_VERSION = "0.10.0";
   var ICONS_CSS_BASE =
     "https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@" +
     ICONS_CSS_VERSION +

--- a/docs/layouts/_default/css-icons.html
+++ b/docs/layouts/_default/css-icons.html
@@ -4,11 +4,11 @@
   <head>
     {{ partial "head" . }}
     <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.9.0/css/modus-icons-regular.css" />
+      href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.10.0/css/modus-icons-regular.css" />
     <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.9.0/css/modus-icons-fill.css" />
+      href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.10.0/css/modus-icons-fill.css" />
     <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.9.0/css/modus-icons-duotone.css" />
+      href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.10.0/css/modus-icons-duotone.css" />
     <style>
       /* Large grid preview only — modal/button icons use package default (24px) */
       #css-icons-list [class^="modus-icon-"] {

--- a/docs/layouts/_default/home.html
+++ b/docs/layouts/_default/home.html
@@ -3,9 +3,9 @@
   <head>
     {{ partial "head" . }}
     {{ partial "analytics" . }}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.0.3/dist/modus-icons-regular.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.0.3/dist/modus-icons-fill.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.0.3/dist/modus-icons-duotone.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.10.0/css/modus-icons-regular.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.10.0/css/modus-icons-fill.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons-css@0.10.0/css/modus-icons-duotone.css" />
     <style>
       site-search {
         display: none !important;


### PR DESCRIPTION
## Summary
- Bump CSS Icons gallery and home page CDN from `0.9.0` / `0.0.3` to `@trimble-oss/modus-icons-css@0.10.0`
- Fix home page path from `/dist/` to `/css/` (current package layout)
- After merge, run **Azure Static Web Apps** deploy so modus-icons.trimble.com picks up Community extras

## Test plan
- [ ] Open `/css-icons/` after deploy and search for `warehouse` or `truck-clock`
- [ ] Confirm home page icon cards still render (regular/fill/duotone)


Made with [Cursor](https://cursor.com)