### PR TITLE
Skip Azure SWA preview when staging environments are exhausted

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy-preview.yml
+++ b/.github/workflows/azure-static-web-apps-deploy-preview.yml
@@ -12,33 +12,44 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
+      - name: Skip preview deploy for Dependabot
+        if: github.actor == 'dependabot[bot]'
+        run: echo "Skipping Azure preview deploy for Dependabot. Open Dependabot PRs exhaust Static Web Apps staging environments."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.actor != 'dependabot[bot]'
         with:
           persist-credentials: false
           submodules: true
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: github.actor != 'dependabot[bot]'
         with:
           node-version: 20
           cache: "npm"
 
       - name: Install npm dependencies
+        if: github.actor != 'dependabot[bot]'
         run: npm ci
 
       - name: Install Angular setup
+        if: github.actor != 'dependabot[bot]'
         run: npm run install:components
 
       - name: Build the icons
+        if: github.actor != 'dependabot[bot]'
         run: npm run build
 
       - name: Build the docs
+        if: github.actor != 'dependabot[bot]'
         run: npm run docs:build
 
       - name: Delete any duplicate Azure Static Web Apps comments
+        if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
         continue-on-error: true
         run: |
           gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments `
@@ -52,7 +63,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build And Deploy
+        if: github.actor != 'dependabot[bot]'
         id: builddeploy
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AMBITIOUS_SKY_021D71010 }}
@@ -71,6 +84,7 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
+        continue-on-error: true
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AMBITIOUS_SKY_021D71010 }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Azure Static Web Apps preview deploys fail on pull requests with:

`This Static Web App already has the maximum number of staging environments`

That is a **quota** error, not a docs/build failure. Open Dependabot PRs each take a staging slot, so later PRs (including security bumps) fail the required **Build and Deploy Job**.

### Changes in [`.github/workflows/azure-static-web-apps-deploy-preview.yml`](.github/workflows/azure-static-web-apps-deploy-preview.yml)

- Skip preview **build/upload** when `github.actor` is `dependabot[bot]` (job still succeeds so required checks are not stuck).
- PR preview **upload** uses `continue-on-error` so a full staging pool does not fail the check. Icon/docs build still runs and can still fail the job.
- Deploys on **push to `main`** still fail the job if Azure errors.
- Closing a PR still tries to release the staging environment (`continue-on-error` so a missing env does not fail).

Same workflow change is also on #839 and #840 so those PRs pick it up without waiting for this one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Workflow YAML only. Closing extra Dependabot PRs or Azure staging environments is still the way to get real PR previews again.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf6e32ce-1caf-4cdf-96d3-ea3ec3e625a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf6e32ce-1caf-4cdf-96d3-ea3ec3e625a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

